### PR TITLE
feat: add local_ld_library_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ custom:
       - packager:
           name: tensorflow
           version: 1.4.0
-          local_ld_library_path: /usr/local/cuda/lib64 # will allow you to run `serverless invoke local`
+        local_ld_library_path: /usr/local/cuda/lib64 # will allow you to run `serverless invoke local`
 ```
 
 - **packager.name** is required. This is the packager name identifier for TensorFlow: **tensorflow**

--- a/README.md
+++ b/README.md
@@ -75,10 +75,12 @@ custom:
       - packager:
           name: tensorflow
           version: 1.4.0
+          local_ld_library_path: /usr/local/cuda/lib64 # will allow you to run `serverless invoke local`
 ```
 
 - **packager.name** is required. This is the packager name identifier for TensorFlow: **tensorflow**
 - **packager.version** is required. This will determine which TensorFlow version you want to build.
+- **packager.local_ld_library_path** is optional. It gives you the opportunity to add the local path to your non-packaed library in order to run `serverless invoke local` using your local library installation
 
 #### Build your own packager
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const createDirectories = require('./src/action/createDirectories');
 const copyServerlessArtifacts = require('./src/action/copyServerlessArtifacts');
 const fetchLibraries = require('./src/action/fetchLibraries');
 const packDependencies = require('./src/action/packDependencies');
+const addLocalLdLibraryPath = require('./src/action/addLocalLdLibraryPath');
 const { isVerbose, vlog, debug } = require('./src/util/cli');
 
 const EPHEMERAL_DIR_NAME = '.ephemeral';
@@ -36,6 +37,7 @@ class ServerlessEphemeral {
             createDirectories,
             copyServerlessArtifacts,
             fetchLibraries,
+            addLocalLdLibraryPath,
             packDependencies // eslint-disable-line comma-dangle
         );
 
@@ -57,6 +59,10 @@ class ServerlessEphemeral {
 
             'before:package:finalize': () => BbPromise.bind(this)
                 .then(this.packDependencies),
+
+            'before:invoke:local:invoke': () => BbPromise.bind(this)
+                .then(this.addLocalLdLibraryPath),
+
         };
     }
 }

--- a/spec/action/addLocalLdLibraryPath.spec.js
+++ b/spec/action/addLocalLdLibraryPath.spec.js
@@ -1,0 +1,38 @@
+const test = require('ava');
+
+const action = require('../../src/action/addLocalLdLibraryPath');
+
+function initServerlessValues (act) {
+    act.options = {};
+
+    act.serverless = {
+        service: {
+            getFunction () {
+                return {
+                };
+            },
+        },
+    };
+}
+
+function initEphemeralValues (act) {
+    act.ephemeral = {
+        config: {
+            libraries: [{
+                local_ld_library_path: '/usr/local/cuda/lib64',
+            }, {
+                local_ld_library_path: ['/usr/local/foo/bar', '/usr/local/bar/foo'],
+            }],
+        },
+    };
+}
+
+test.before(() => {
+    initEphemeralValues(action);
+    initServerlessValues(action);
+});
+
+
+test('Add LD_LIBRARY_PATH to function environment variables', t => action.addLocalLdLibraryPath().then(() => {
+    t.is(action.options.functionObj.environment.LD_LIBRARY_PATH, '/usr/local/cuda/lib64:/usr/local/foo/bar:/usr/local/bar/foo:/usr/local/lib64/node-v4.3.x/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib');
+}));

--- a/src/action/addLocalLdLibraryPath.js
+++ b/src/action/addLocalLdLibraryPath.js
@@ -1,0 +1,29 @@
+module.exports = {
+    addLocalLdLibraryPath () {
+        let ldPaths = [];
+        for (let i = 0; i < this.ephemeral.config.libraries.length; i += 1) {
+            if (typeof (this.ephemeral.config.libraries[i].local_ld_library_path) === 'string') {
+                ldPaths.push(this.ephemeral.config.libraries[i].local_ld_library_path);
+            } else if (Array.isArray(this.ephemeral.config.libraries[i].local_ld_library_path)) {
+                ldPaths = ldPaths.concat(this.ephemeral.config.libraries[i].local_ld_library_path);
+            }
+        }
+
+      // from https://github.com/serverless/serverless/blob/4b71faf2128308894646940ce2fb64e826450972/lib/plugins/aws/invokeLocal/index.js#L95
+      // LD_LIBRARY_PATH is hardcoded
+        const awsLibs = '/usr/local/lib64/node-v4.3.x/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib';
+        ldPaths = ldPaths.concat(awsLibs.split(':'));
+
+      // in order to override it, we should inject it into functionObj.environment
+      // it is then merged in https://github.com/serverless/serverless/blob/4b71faf2128308894646940ce2fb64e826450972/lib/plugins/aws/invokeLocal/index.js#L111
+      // it is not the most elegant way but this tricks do the job for now
+
+        this.options.functionObj = this.serverless.service.getFunction(this.options.function);
+
+        if (!this.options.functionObj.environment) {
+            this.options.functionObj.environment = {};
+        }
+        this.options.functionObj.environment.LD_LIBRARY_PATH = ldPaths.join(':');
+        return Promise.resolve();
+    },
+};


### PR DESCRIPTION
This PR is a proposal to fix #13 by adding the ability to set `local_ld_library_path` in ephemeral custom config at library level.

This might not be best design, but LD_LIBRARY_PATH is hardcoded into serverless AWS plugin (see https://github.com/serverless/serverless/blob/4b71faf2128308894646940ce2fb64e826450972/lib/plugins/aws/invokeLocal/index.js#L95), any feedback would be appreciated